### PR TITLE
feat: use deterministic bucket names

### DIFF
--- a/lib/stacks/virtual-participant-stack.ts
+++ b/lib/stacks/virtual-participant-stack.ts
@@ -11,6 +11,7 @@ import {
 } from '@policies';
 import {
   capitalize,
+  createDeterministicBucketName,
   createExportName,
   createResourceName
 } from '@utils/common';
@@ -87,7 +88,7 @@ class VirtualParticipantStack extends Stack {
     // ========== TELEMETRY ==========
 
     const logsBucket = new SecureBucket(this, 'LogsBucket', {
-      bucketName: createResourceName(this, 'Logs', 63, true),
+      bucketName: createDeterministicBucketName(this, 'logs'),
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
       objectOwnership: s3.ObjectOwnership.OBJECT_WRITER, // objectOwnership must be set to "ObjectWriter" when accessControl is "LogDeliveryWrite"
@@ -104,7 +105,7 @@ class VirtualParticipantStack extends Stack {
     // ========== VIDEO ASSETS BUCKET ==========
 
     const videoAssetsBucket = new SecureBucket(this, 'VideoAssetsBucket', {
-      bucketName: createResourceName(this, 'VideoAssets', 63, true),
+      bucketName: createDeterministicBucketName(this, 'videoassets'),
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
       intelligentTieringConfigurations: [


### PR DESCRIPTION
*Description of changes:*
Fixes an issue where deploys could tear down and create a new buckets with new names. Now uses a hash to deterministically generate reasonably unique names for the logs and assets buckets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
